### PR TITLE
Add an optional alphabet scrollbar to libraries views

### DIFF
--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -1158,6 +1158,86 @@
         <orientation>horizontal</orientation>
         <height>54</height>
     </include>
+    <include name="VerticalAlphabetScroller">
+        <width>54</width>
+        <height>897</height>
+        <orientation>vertical</orientation>
+        <itemlayout height="32" width="37">
+            <control type="label">
+                <label>$INFO[ListItem.Label]</label>
+                <align>center</align>
+                <aligny>center</aligny>
+                <include>TextColor_AlternateColor</include>
+                <animation effect="fade" start="100" end="60" time="0" condition="!IsEmpty(ListItem.Property(NotAvailable))">Conditional</animation>
+                <visible>String.IsEmpty(ListItem.Property(NotAvailable))</visible>
+            </control>
+            <control type="label">
+                <label>$INFO[ListItem.Label]</label>
+                <align>center</align>
+                <aligny>center</aligny>
+                <include>TextColor_MidColor</include>
+                <animation effect="fade" start="100" end="35" time="0" condition="!IsEmpty(ListItem.Property(NotAvailable))">Conditional</animation>
+                <visible>!String.IsEmpty(ListItem.Property(NotAvailable))</visible>
+            </control>
+            <control type="label">
+                <label>$INFO[ListItem.Label]</label>
+                <align>center</align>
+                <aligny>center</aligny>
+                <include>TextColor_AlternateColor</include>
+                <visible>String.IsEqual(ListItem.Label,Container.ListItem.SortLetter)</visible>
+                <animation effect="fade" start="100" end="80" time="0" condition="!IsEmpty(ListItem.Property(NotAvailable))">Conditional</animation>
+            </control>
+        </itemlayout>
+        <focusedlayout height="32" width="37">
+            <control type="label">
+                <label>$INFO[ListItem.Label]</label>
+                <align>center</align>
+                <aligny>center</aligny>
+                <include>TextColor_MainColor</include>
+            </control>
+        </focusedlayout>
+        <content>plugin://script.skin.helper.service/?action=alphabet&amp;reload=$INFO[Container.NumItems]</content>
+    </include>
+    <include name="HorizontalAlphabetScroller">
+        <height>54</height>
+        <width>1920</width>
+        <orientation>horizontal</orientation>
+        <itemlayout height="32" width="71">
+            <control type="label">
+                <label>$INFO[ListItem.Label]</label>
+                <align>center</align>
+                <aligny>center</aligny>
+                <include>TextColor_AlternateColor</include>
+                <animation effect="fade" start="100" end="60" time="0" condition="!IsEmpty(ListItem.Property(NotAvailable))">Conditional</animation>
+                <visible>String.IsEmpty(ListItem.Property(NotAvailable))</visible>
+            </control>
+            <control type="label">
+                <label>$INFO[ListItem.Label]</label>
+                <align>center</align>
+                <aligny>center</aligny>
+                <include>TextColor_MidColor</include>
+                <animation effect="fade" start="100" end="35" time="0" condition="!IsEmpty(ListItem.Property(NotAvailable))">Conditional</animation>
+                <visible>!String.IsEmpty(ListItem.Property(NotAvailable))</visible>
+            </control>
+            <control type="label">
+                <label>$INFO[ListItem.Label]</label>
+                <align>center</align>
+                <aligny>center</aligny>
+                <include>TextColor_AlternateColor</include>
+                <visible>String.IsEqual(ListItem.Label,Container.ListItem.SortLetter)</visible>
+                <animation effect="fade" start="100" end="80" time="0" condition="!IsEmpty(ListItem.Property(NotAvailable))">Conditional</animation>
+            </control>
+        </itemlayout>
+        <focusedlayout height="32" width="71">
+            <control type="label">
+                <label>$INFO[ListItem.Label]</label>
+                <align>center</align>
+                <aligny>center</aligny>
+                <include>TextColor_MainColor</include>
+            </control>
+        </focusedlayout>
+        <content>plugin://script.skin.helper.service/?action=alphabet&amp;reload=$INFO[Container.NumItems]</content>
+    </include>
     <include name="myautoscroll">
         <autoscroll delay="5000" time="2500" repeat="10000">true</autoscroll>
     </include>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -82,6 +82,18 @@
                             <onclick>Skin.ToggleSetting(ManualScroll)</onclick>
                         </item>
                         <item id="19">
+                            <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                            <label>$LOCALIZE[32000]</label>
+                            <label2>$LOCALIZE[107]</label2>
+                            <onclick>Skin.ToggleSetting(AlphabetJumpScrollBar)</onclick>
+                        </item>
+                        <item id="19">
+                            <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
+                            <label>$LOCALIZE[32000]</label>
+                            <label2>$LOCALIZE[106]</label2>
+                            <onclick>Skin.ToggleSetting(AlphabetJumpScrollBar)</onclick>
+                        </item>
+                        <item id="19">
                             <visible>Skin.HasSetting(ScrollOffsetLabelEnabled)</visible>
                             <label>$LOCALIZE[31941]</label>
                             <label2>$LOCALIZE[107]</label2>

--- a/1080i/View_5050_CardList.xml
+++ b/1080i/View_5050_CardList.xml
@@ -442,10 +442,20 @@
                 </control>
             </control>
             <control type="scrollbar" id="60">
+                <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
                 <posx>0</posx>
                 <posy>1046</posy>
                 <width>1920</width>
                 <include>HorizontalScroller</include>
+                <onup>5050</onup>
+                <onright>noop</onright>
+                <ondown>505050</ondown>
+            </control>
+            <control type="panel" id="60">
+                <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                <posx>0</posx>
+                <posy>1024</posy>
+                <include>HorizontalAlphabetScroller</include>
                 <onup>5050</onup>
                 <onright>noop</onright>
                 <ondown>505050</ondown>

--- a/1080i/View_50_BigList.xml
+++ b/1080i/View_50_BigList.xml
@@ -302,10 +302,19 @@
                 </control>
             </control>
             <control type="scrollbar" id="60">
+                <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
                 <posx>1886</posx>
                 <posy>183</posy>
                 <height>810</height>
                 <include>VerticalScroller</include>
+                <onleft>50</onleft>
+                <onright>505050</onright>
+            </control>
+            <control type="panel" id="60">
+                <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                <posx>1886</posx>
+                <posy>183</posy>
+                <include>VerticalAlphabetScroller</include>
                 <onleft>50</onleft>
                 <onright>505050</onright>
             </control>
@@ -358,10 +367,19 @@
                 </control>
             </control>
             <control type="scrollbar" id="60">
+                <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
                 <posx>1886</posx>
                 <posy>183</posy>
                 <height>810</height>
                 <include>VerticalScroller</include>
+                <onleft>51</onleft>
+                <onright>60</onright>
+            </control>
+            <control type="panel" id="60">
+                <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                <posx>1886</posx>
+                <posy>183</posy>
+                <include>VerticalAlphabetScroller</include>
                 <onleft>51</onleft>
                 <onright>60</onright>
             </control>
@@ -449,10 +467,19 @@
                 </control>
             </control>
             <control type="scrollbar" id="60">
+                <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
                 <posx>1886</posx>
                 <posy>183</posy>
                 <height>810</height>
                 <include>VerticalScroller</include>
+                <onleft>50</onleft>
+                <onright>505050</onright>
+            </control>
+            <control type="panel" id="60">
+                <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                <posx>1886</posx>
+                <posy>183</posy>
+                <include>VerticalAlphabetScroller</include>
                 <onleft>50</onleft>
                 <onright>505050</onright>
             </control>
@@ -656,10 +683,19 @@
                 <include>WeatherContent</include>
             </control>
             <control type="scrollbar" id="60">
+                <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
                 <posx>1886</posx>
                 <posy>183</posy>
                 <height>810</height>
                 <include>VerticalScroller</include>
+                <onleft>50</onleft>
+                <onright>505050</onright>
+            </control>
+            <control type="panel" id="60">
+                <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                <posx>1886</posx>
+                <posy>183</posy>
+                <include>VerticalAlphabetScroller</include>
                 <onleft>50</onleft>
                 <onright>505050</onright>
             </control>

--- a/1080i/View_51_SlimList.xml
+++ b/1080i/View_51_SlimList.xml
@@ -288,10 +288,19 @@
                 </control>
             </control>
             <control type="scrollbar" id="60">
+                <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
                 <posx>1886</posx>
                 <posy>183</posy>
                 <height>810</height>
                 <include>VerticalScroller</include>
+                <onleft>51</onleft>
+                <onright>505050</onright>
+            </control>
+            <control type="panel" id="60">
+                <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                <posx>1886</posx>
+                <posy>183</posy>
+                <include>VerticalAlphabetScroller</include>
                 <onleft>51</onleft>
                 <onright>505050</onright>
             </control>

--- a/1080i/View_52_ShortList.xml
+++ b/1080i/View_52_ShortList.xml
@@ -371,10 +371,19 @@
                 </control>
             </control>
             <control type="scrollbar" id="60">
+                <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
                 <posx>1886</posx>
                 <posy>183</posy>
                 <height>810</height>
                 <include>VerticalScroller</include>
+                <onleft>52</onleft>
+                <onright>505050</onright>
+            </control>
+            <control type="panel" id="60">
+                <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                <posx>1886</posx>
+                <posy>183</posy>
+                <include>VerticalAlphabetScroller</include>
                 <onleft>52</onleft>
                 <onright>505050</onright>
             </control>
@@ -569,10 +578,19 @@
                 <include>WeatherContent</include>
             </control>
             <control type="scrollbar" id="60">
+                <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
                 <posx>1886</posx>
                 <posy>183</posy>
                 <height>810</height>
                 <include>VerticalScroller</include>
+                <onleft>52</onleft>
+                <onright>505050</onright>
+            </control>
+            <control type="panel" id="60">
+                <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                <posx>1886</posx>
+                <posy>183</posy>
+                <include>VerticalAlphabetScroller</include>
                 <onleft>52</onleft>
                 <onright>505050</onright>
             </control>

--- a/1080i/View_55_Panel.xml
+++ b/1080i/View_55_Panel.xml
@@ -526,10 +526,19 @@
                 </control>
             </control>
             <control type="scrollbar" id="60">
+                <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
                 <posx>1886</posx>
                 <posy>183</posy>
                 <height>897</height>
                 <include>VerticalScroller</include>
+                <onleft>50</onleft>
+                <onright>60</onright>
+            </control>
+            <control type="panel" id="60">
+                <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                <posx>1886</posx>
+                <posy>183</posy>
+                <include>VerticalAlphabetScroller</include>
                 <onleft>50</onleft>
                 <onright>60</onright>
             </control>

--- a/1080i/View_56_BannerList.xml
+++ b/1080i/View_56_BannerList.xml
@@ -196,10 +196,19 @@
                 </control>
             </control>
             <control type="scrollbar" id="60">
+                <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
                 <posx>1886</posx>
                 <posy>183</posy>
                 <height>810</height>
                 <include>VerticalScroller</include>
+                <onleft>56</onleft>
+                <onright>505050</onright>
+            </control>
+            <control type="panel" id="60">
+                <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                <posx>1886</posx>
+                <posy>183</posy>
+                <include>VerticalAlphabetScroller</include>
                 <onleft>56</onleft>
                 <onright>505050</onright>
             </control>

--- a/1080i/View_57_58_59_Showcase.xml
+++ b/1080i/View_57_58_59_Showcase.xml
@@ -227,10 +227,19 @@
                 </focusedlayout>
             </control>
             <control type="scrollbar" id="609">
+                <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
                 <posx>0</posx>
                 <posy>1046</posy>
                 <width>1920</width>
                 <include>HorizontalScroller</include>
+                <onup>59</onup>
+                <ondown>505050</ondown>
+            </control>
+            <control type="panel" id="609">
+                <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                <posx>0</posx>
+                <posy>1024</posy>
+                <include>HorizontalAlphabetScroller</include>
                 <onup>59</onup>
                 <ondown>505050</ondown>
             </control>
@@ -492,10 +501,19 @@
                 </focusedlayout>
             </control>
             <control type="scrollbar" id="608">
+                <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
                 <posx>0</posx>
                 <posy>1046</posy>
                 <width>1920</width>
                 <include>HorizontalScroller</include>
+                <onup>58</onup>
+                <ondown>505050</ondown>
+            </control>
+            <control type="panel" id="608">
+                <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                <posx>0</posx>
+                <posy>1024</posy>
+                <include>HorizontalAlphabetScroller</include>
                 <onup>58</onup>
                 <ondown>505050</ondown>
             </control>
@@ -730,10 +748,19 @@
                 </focusedlayout>
             </control>
             <control type="scrollbar" id="607">
+                <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
                 <posx>0</posx>
                 <posy>1046</posy>
                 <width>1920</width>
                 <include>HorizontalScroller</include>
+                <onup>57</onup>
+                <ondown>505050</ondown>
+            </control>
+            <control type="panel" id="607">
+                <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                <posx>0</posx>
+                <posy>1024</posy>
+                <include>HorizontalAlphabetScroller</include>
                 <onup>57</onup>
                 <ondown>505050</ondown>
             </control>
@@ -952,10 +979,19 @@
                 <include>WeatherContent</include>
             </control>
             <control type="scrollbar" id="607">
+                <visible>![Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)]</visible>
                 <posx>0</posx>
                 <posy>1046</posy>
                 <width>1920</width>
                 <include>HorizontalScroller</include>
+                <onup>57</onup>
+                <ondown>505050</ondown>
+            </control>
+            <control type="panel" id="607">
+                <visible>Skin.HasSetting(AlphabetJumpScrollBar) + Integer.IsGreater(Container.NumItems,100)</visible>
+                <posx>0</posx>
+                <posy>1024</posy>
+                <include>HorizontalAlphabetScroller</include>
                 <onup>57</onup>
                 <ondown>505050</ondown>
             </control>

--- a/language/Chinese (Simple)/strings.po
+++ b/language/Chinese (Simple)/strings.po
@@ -495,3 +495,7 @@ msgstr "在首页菜单使用固定列表"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "列表视图左侧收起动画"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "使用字母滚动查看大列表"

--- a/language/Dutch/strings.po
+++ b/language/Dutch/strings.po
@@ -763,3 +763,7 @@ msgstr "Gebruik gefixeerde lijst bij hoofdmenu"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Schuif naar links voor animaties van weergavenlijst"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "Gebruik alfabetische scroll voor grote lijsten"

--- a/language/English (Australia)/strings.po
+++ b/language/English (Australia)/strings.po
@@ -767,3 +767,7 @@ msgstr "Use fixed list on Home Menu"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Slide to left animations of list views"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "Use alphabet scroll for large lists"

--- a/language/English (New Zealand)/strings.po
+++ b/language/English (New Zealand)/strings.po
@@ -667,3 +667,7 @@ msgstr "Use fixed list on Home Menu"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Slide to left animations of list views"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "Use alphabet scroll for large lists"

--- a/language/English (US)/strings.po
+++ b/language/English (US)/strings.po
@@ -767,3 +767,7 @@ msgstr "Use fixed list on Home Menu"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Slide to left animations of list views"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "Use alphabet scroll for large lists"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1082,3 +1082,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr ""

--- a/language/French (Canada)/strings.po
+++ b/language/French (Canada)/strings.po
@@ -763,3 +763,7 @@ msgstr "Utiliser des listes fixes pour le menu d’accueil"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Glisser vers la gauche les animations des vues de listes"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "Utiliser le défilement alphabétique pour les grandes listes"

--- a/language/French/strings.po
+++ b/language/French/strings.po
@@ -763,3 +763,7 @@ msgstr "Coulisser vers la gauche les animation des vues format liste"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Coulisser vers la gauche les animation des vues format liste"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "Utiliser le défilement alphabétique pour les grandes listes"

--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -1060,3 +1060,7 @@ msgstr "Feste Liste im Hauptmenü verwenden"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Nach links Verschiebeanimationen in der Listenansicht"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "Verwenden Sie die Alphabet-Schriftrolle für große Listen"

--- a/language/Greek/strings.po
+++ b/language/Greek/strings.po
@@ -603,3 +603,7 @@ msgstr "Χρήση καθορισμένης λίστας στο Κεντρικό
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Εφέ κύλισης στα αριστερά για λίστες"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "Χρησιμοποιήστε κύλιση αλφαβήτου για μεγάλες λίστες"

--- a/language/Hebrew/strings.po
+++ b/language/Hebrew/strings.po
@@ -989,3 +989,7 @@ msgstr "תשתמש ברשימה מקובעת בתפריט הבית"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "הנפשות החלקה לשמאל של תצוגות רשימה"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "השתמש בגלילה אלפביתית עבור רשימות גדולות"

--- a/language/Italian/strings.po
+++ b/language/Italian/strings.po
@@ -931,3 +931,7 @@ msgstr "Utilizza lista fissa nel Menu Home"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Animazioni di scorrimento a sinistra delle liste"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "Usa lo scorrimento alfabetico per elenchi di grandi dimensioni"

--- a/language/Korean/strings.po
+++ b/language/Korean/strings.po
@@ -747,3 +747,7 @@ msgstr "홈 메뉴에 고정 목록 사용"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "목록 보기에서 왼쪽으로 당기기 사용"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "큰 목록에는 알파벳 스크롤 사용"

--- a/language/Lithuanian/strings.po
+++ b/language/Lithuanian/strings.po
@@ -763,3 +763,7 @@ msgstr "Naudoti fiksuotą sąrašą pagrindiniame meniu"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Sąrašo rodinių slinkimo į kairę animacija "
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "Jei norite sudaryti didelius sąrašus, naudokite abėcėlės slinktį"

--- a/language/Malay/strings.po
+++ b/language/Malay/strings.po
@@ -763,3 +763,7 @@ msgstr "Guna senarai tetap dalam Menu Rumah"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Leret ke kiri animasi bagi paparan senarai"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "Gunakan tatal abjad untuk senarai besar"

--- a/language/Polish/strings.po
+++ b/language/Polish/strings.po
@@ -763,3 +763,7 @@ msgstr "Używaj stałej listy menu startowego"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Przesuwaj widok list do lewej"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "W przypadku dużych list użyj przewijania alfabetu"

--- a/language/Portuguese (Brazil)/strings.po
+++ b/language/Portuguese (Brazil)/strings.po
@@ -759,3 +759,7 @@ msgstr "Usar lista fixa no Menu Inicial"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Animações Deslizar para Esquerda nas visualizações de lista"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "Use a rolagem do alfabeto para listas grandes"

--- a/language/Portuguese/strings.po
+++ b/language/Portuguese/strings.po
@@ -727,3 +727,7 @@ msgstr "Utilizar lista fixa no Menu Principal"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Animação deslisa para a esquerda em vistas de tipo lista"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "Use a rolagem do alfabeto para listas grandes"

--- a/language/Spanish/strings.po
+++ b/language/Spanish/strings.po
@@ -639,3 +639,7 @@ msgstr "Usar lista fija en el Menú Principal"
 msgctxt "#31999"
 msgid "Slide to left animations of list views"
 msgstr "Deslizar animaciones hacia la izquierda en la vista de lista"
+
+msgctxt "#32000"
+msgid "Use alphabet scroll for large lists"
+msgstr "Utilice el desplazamiento alfabético para listas grandes"


### PR DESCRIPTION
when there is lots of items.

When the setting is enabled, it replaced the scroll bars with something that looks like this.
![alphabet scroll](https://user-images.githubusercontent.com/6151791/96998014-85377980-157e-11eb-83b5-11df81908012.png)
